### PR TITLE
Ignore implausible statistic updates

### DIFF
--- a/dpppt-additionalinfo-backend/src/main/java/org/dpppt/additionalinfo/backend/ws/statistics/MockStatisticClient.java
+++ b/dpppt-additionalinfo-backend/src/main/java/org/dpppt/additionalinfo/backend/ws/statistics/MockStatisticClient.java
@@ -1,33 +1,47 @@
 package org.dpppt.additionalinfo.backend.ws.statistics;
 
 import java.time.LocalDate;
-
+import java.util.Random;
 import org.dpppt.additionalinfo.backend.ws.model.statistics.History;
 import org.dpppt.additionalinfo.backend.ws.model.statistics.Statistics;
 
 public class MockStatisticClient implements StatisticClient {
-	@Override
-	public Statistics getStatistics() {
-		LocalDate today = LocalDate.now();
-		Statistics statistics = new Statistics();
-		statistics.setTotalActiveUsers(1623942);
-		statistics.setLastUpdated(today);
-		LocalDate dayDate = LocalDate.now().minusDays(21);
-		for (int i = 0; dayDate.isBefore(today); i++) {
-			History history = new History();
-			history.setDate(dayDate);
-			history.setCovidcodesEntered(50 + i * 2);
-			if (i > 1 && i < 20) {
-				history.setNewInfections((int) (210 + Math.pow(i, 2)));
-			}
-			// history.setNewInfectionsSevenDayAverage((int) (250 + Math.pow(i, 2)));
-			statistics.getHistory().add(history);
 
-			dayDate = dayDate.plusDays(1);
-		}
+    private boolean mockImplausible = false;
+    private Random rand = new Random();
 
-		StatisticHelper.calculateRollingAverage(statistics);
+    /**
+     * returns an implausible total active users value on every second method call
+     *
+     * @return
+     */
+    @Override
+    public Statistics getStatistics() {
+        LocalDate today = LocalDate.now();
+        Statistics statistics = new Statistics();
+        int totalActiveUsers = 1600000 + rand.nextInt(250000);
+        if (mockImplausible) {
+            totalActiveUsers /= 4;
+        }
+        statistics.setTotalActiveUsers(totalActiveUsers);
+        statistics.setLastUpdated(today);
+        LocalDate dayDate = LocalDate.now().minusDays(21);
+        for (int i = 0; dayDate.isBefore(today); i++) {
+            History history = new History();
+            history.setDate(dayDate);
+            history.setCovidcodesEntered(50 + i * 2);
+            if (i > 1 && i < 20) {
+                history.setNewInfections((int) (210 + Math.pow(i, 2)));
+            }
+            // history.setNewInfectionsSevenDayAverage((int) (250 + Math.pow(i, 2)));
+            statistics.getHistory().add(history);
 
-		return statistics;
-	}
+            dayDate = dayDate.plusDays(1);
+        }
+
+        StatisticHelper.calculateRollingAverage(statistics);
+
+        mockImplausible = !mockImplausible;
+        return statistics;
+    }
 }


### PR DESCRIPTION
Splunk sometimes returns incomplete numbers while importing data during the night. This PR ignores implausible statistics data when loading the numbers from Splunk. 